### PR TITLE
Add mongoose dependency to Fatures.ts

### DIFF
--- a/packages/cli/src/services/Features.ts
+++ b/packages/cli/src/services/Features.ts
@@ -228,7 +228,8 @@ registerProvider({
             value: {
               type: "mongoose",
               dependencies: {
-                "@tsed/mongoose": "{{tsedVersion}}"
+                "@tsed/mongoose": "{{tsedVersion}}",
+                "mongoose": "latest"
               },
               devDependencies: {
                 // "@tsed/cli-plugin-mongoose": cliVersion

--- a/packages/cli/src/services/Features.ts
+++ b/packages/cli/src/services/Features.ts
@@ -229,6 +229,7 @@ registerProvider({
               type: "mongoose",
               dependencies: {
                 "@tsed/mongoose": "{{tsedVersion}}",
+                "@types/mongoose": "latest",
                 "mongoose": "latest"
               },
               devDependencies: {


### PR DESCRIPTION
When I choose mongoose, It must need "mongoose"

```
Error: Cannot find module 'mongoose'
Require stack:
- D:\my-projects\my-blog\node_modules\@tsed\mongoose\lib\services\MongooseService.js
- D:\my-projects\my-blog\node_modules\@tsed\mongoose\lib\index.js
- D:\my-projects\my-blog\src\Server.ts
- D:\my-projects\my-blog\src\controllers\HelloWorldController.integration.spec.ts
- D:\my-projects\my-blog\node_modules\mocha\lib\esm-utils.js
- D:\my-projects\my-blog\node_modules\mocha\lib\mocha.js
- D:\my-projects\my-blog\node_modules\mocha\lib\cli\one-and-dones.js
- D:\my-projects\my-blog\node_modules\mocha\lib\cli\options.js
- D:\my-projects\my-blog\node_modules\mocha\bin\mocha
```