### PR TITLE
Fixes for typeorm and jest when initializing a new project

### DIFF
--- a/packages/cli-plugin-jest/src/hooks/JestInitHook.ts
+++ b/packages/cli-plugin-jest/src/hooks/JestInitHook.ts
@@ -28,7 +28,7 @@ export class JestInitHook {
   onInitExec() {
     return [
       {
-        title: "Generate files for mocha",
+        title: "Generate files for jest",
         task: (ctx: any) => {
           return this.rootRenderer.renderAll(["init/jest.config.js.hbs"], ctx, {
             templateDir: TEMPLATE_DIR
@@ -36,7 +36,7 @@ export class JestInitHook {
         }
       },
       {
-        title: "Generate scripts files for mocha",
+        title: "Generate scripts files for jest",
         task: (ctx: any) => {
           return this.scriptsRenderer.renderAll(["init/setup.jest.js.hbs"], ctx, {
             templateDir: TEMPLATE_DIR,

--- a/packages/cli-plugin-jest/templates/generate/generic.integration.hbs
+++ b/packages/cli-plugin-jest/templates/generate/generic.integration.hbs
@@ -1,4 +1,4 @@
-import { PlatformApplication, ServerLoader } from "@tsed/common";
+import { PlatformApplication } from "@tsed/common";
 import { TestContext } from "@tsed/testing";
 import * as SuperTest from "supertest";
 import { {{symbolName}} } from "./{{symbolPathBasename}}";

--- a/packages/cli-plugin-typeorm/templates/index.hbs
+++ b/packages/cli-plugin-typeorm/templates/index.hbs
@@ -1,6 +1,6 @@
 // @tsed/cli do not edit
 {{#forEach configs}}
-import {{symbolName}}Config from "./{{name}}.config.json";
+import * as {{symbolName}}Config from "./{{name}}.config.json";
 {{/forEach}}
 
 export default [


### PR DESCRIPTION
These two small errors made a new installation fail due to an eslint error and an undefined property 'name' error.
With these fixes, a new project with jest and typeorm as selected options starts without errors.