### PR TITLE
fix: Remove deprecation warning on generated models

### DIFF
--- a/packages/cli/templates/generate/model.hbs
+++ b/packages/cli/templates/generate/model.hbs
@@ -1,4 +1,4 @@
-import {Property} from "@tsed/common";
+import {Property} from "@tsed/schema";
 
 export class {{symbolName}} {
   @Property()


### PR DESCRIPTION
Hi, this is a simple change to fix the deprecation warning when generating a model via the CLI.