### PR TITLE
Add tsconfig-paths to dev-dependency

### DIFF
--- a/packages/cli/src/commands/init/InitCmd.ts
+++ b/packages/cli/src/commands/init/InitCmd.ts
@@ -277,6 +277,7 @@ export class InitCmd implements CommandProvider {
         concurrently: "latest",
         nodemon: "latest",
         "ts-node": "latest",
+        "tsconfig-paths": "latest",
         typescript: "latest"
       },
       ctx


### PR DESCRIPTION
Adding tsconfig-paths to dev-dep to prevent the following error from occurring.
```
❯ yarn start
yarn run v1.22.10
warning package.json: No license field
$ tsnd --inspect --ignore-watch node_modules --respawn --transpile-only -r tsconfig-paths/register src/index.ts
[INFO] 00:47:24 ts-node-dev ver. 1.1.1 (using ts-node ver. 9.1.1, typescript ver. 4.1.3)
Debugger listening on ws://127.0.0.1:9229/7cdfe72b-2136-49c0-8940-e3971d297e43
For help, see: https://nodejs.org/en/docs/inspector
Error: Cannot find module 'tsconfig-paths/register'
Require stack:
- internal/preload
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at Module._preloadModules (internal/modules/cjs/loader.js:1217:12)
    at loadPreloadModules (internal/bootstrap/pre_execution.js:449:5)
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:76:3)
    at internal/main/run_main_module.js:7:1
```