### PR TITLE
Remove debug instruction

### DIFF
--- a/packages/cli/src/commands/init/InitCmd.ts
+++ b/packages/cli/src/commands/init/InitCmd.ts
@@ -129,7 +129,6 @@ export class InitCmd implements CommandProvider {
 
   async $beforeExec(ctx: InitCmdContext): Promise<any> {
     this.fs.ensureDirSync(this.packageJson.dir);
-    console.log(ctx.projectName);
     this.packageJson.name = ctx.projectName;
 
     ctx.packageManager && this.packageJson.setPreference("packageManager", ctx.packageManager);


### PR DESCRIPTION
I think this `console.log` was added only for debug purposes and it was meant to be removed